### PR TITLE
Fixes for fetching collections with relationships

### DIFF
--- a/lib/responses/ok.js
+++ b/lib/responses/ok.js
@@ -13,12 +13,10 @@ module.exports = function sendOK(data) {
   var JSONAPISerializer = require('jsonapi-serializer').Serializer;
   var modelUtils = require('../utils/model-utils');
   var normUtils = require('../utils/norm-utils');
-  var pluralize = require('pluralize');
   var Model,
       modelName,
-      pluralModel,
       opts,
-      relatedModelNames,
+      relationships,
       jsonApiRes;
 
   // Get access to `req`, `res`, & `sails`
@@ -37,20 +35,21 @@ module.exports = function sendOK(data) {
     attributes: modelUtils.getAttributes(Model)
   };
   // Add related model data
-  relatedModelNames = modelUtils.getRelatedModelNames(req);
-  relatedModelNames.forEach(function (model) {
-    pluralModel = pluralize(model);
-    Model = sails.models[model];
+  relationships = modelUtils.getRelationships(req);
+  relationships.forEach(function (relationship) {
+    var alias = relationship.alias;
+    var collection = relationship.model || relationship.collection;
+    Model = sails.models[collection];
     // Related model attributes
-    opts[pluralModel] = {
+    opts[alias] = {
       attributes: modelUtils.getOwnAttributes(Model)
     };
     // Compound Document options
     if (sails.config.jsonapi.compoundDoc) {
       modelUtils.getRef(Model, function (ref) {
-        opts[pluralModel].ref = ref;
+        opts[alias].ref = ref;
       });
-      opts[pluralModel].included = sails.config.jsonapi.included;
+      opts[alias].included = sails.config.jsonapi.included;
     }
   });
 

--- a/lib/utils/model-utils.js
+++ b/lib/utils/model-utils.js
@@ -1,7 +1,5 @@
 'use strict';
 
-var pluralize = require('pluralize');
-
 // Only attributes which are not primary key ('id') or have an alias (relationship)
 exports.getOwnAttributes = function (Model) {
   var ownAttrs = [];
@@ -38,12 +36,7 @@ exports.getModelName = function (req) {
   return req.options.model;
 };
 
-// Returns singular-ized model names of related models
-exports.getRelatedModelNames = function (req) {
-  var rels = [];
-  req.options.associations.forEach(function (assoc) {
-    var model = pluralize(assoc.alias, 1);
-    rels.push(model);
-  });
-  return rels;
+// Returns array of relationships for collection accessed by request
+exports.getRelationships = function (req) {
+  return req.options.associations;
 };

--- a/tests/dummy/api/models/Author.js
+++ b/tests/dummy/api/models/Author.js
@@ -16,6 +16,9 @@ module.exports = {
       collection: 'book',
       via: 'author'
     },
+    groupies: {
+      collection: 'user',
+      via: 'groupieOf'
+    }
   }
 };
-

--- a/tests/dummy/api/models/User.js
+++ b/tests/dummy/api/models/User.js
@@ -12,7 +12,12 @@ module.exports = {
     firstName: 'STRING',
     lastName: 'STRING',
     email: 'EMAIL',
-    password: 'STRING'
+    password: 'STRING',
+
+    // relationships
+    groupieOf: {
+      collection: 'author',
+      via: 'groupies'
+    }
   }
 };
-


### PR DESCRIPTION
Do not assume that association model is singular alias. `collection` (many-to relationship) or `model` (one-to relationship) is model name. `alias` might or might not be pluralized model name.