### PR TITLE
Do not support to include related ressources as attributes

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,9 +25,7 @@ Create a `jsonapi.js` file inside the `config/` directory of your app, and you c
 
 | Option        | Default   |  Description  |
 |---------------|:---------:|---------------|
-| `compoundDoc` |  `true`   | When set to 'true' (default), response will be a [compound document](http://jsonapi.org/format/#document-compound-documents). Otherwise, related resources will be nested within the top-level resource attributes. |
-| `included`    |  `true`   | When set to `true` (default), related resource data will be [included](http://jsonapi.org/format/#fetching-includes) in the response. Currently, `include` parameters in client requests are not supported.  |
-
+| `compoundDoc` |  `true`   | When set to 'true' (default), response will be a [compound document](http://jsonapi.org/format/#document-compound-documents) including related resources. |
 
 ### Known Limitations
 

--- a/lib/responses/json.js
+++ b/lib/responses/json.js
@@ -74,13 +74,12 @@ module.exports = function json() {
     opts[alias] = {
       attributes: modelUtils.getOwnAttributes(Model)
     };
+    // add models as relationships
+    modelUtils.getRef(Model, function (ref) {
+      opts[alias].ref = ref;
+    });
     // Compound Document options
-    if (sails.config.jsonapi.compoundDoc) {
-      modelUtils.getRef(Model, function (ref) {
-        opts[alias].ref = ref;
-      });
-      opts[alias].included = sails.config.jsonapi.included;
-    }
+    opts[alias].included = sails.config.jsonapi.compoundDoc;
   });
 
   // normalize relationships


### PR DESCRIPTION
A related ressource should not be included as an attribute value:

> Although has-one foreign keys (e.g. author_id) are often stored internally
> alongside other information to be represented in a resource object, these
> keys SHOULD NOT appear as attributes.

Resource objects have a *relationships* property which should describe it's
relationships. Relationships could be described by link objects or resource
linkage. Resource linkage must be used if it's a compound document.

Of course an attributes value may be a JSON object or an array:

> Complex data structures involving JSON objects and arrays are allowed as
> attribute values. However, any object that constitutes or is contained in
> an attribute MUST NOT contain a relationships or links member, as those
> members are reserved by this specification for future use.

Better explained in these these issue:
https://github.com/json-api/json-api/issues/902

> The case that is most correct is the last one (i.e. relationships are
> always present). The only time when a relationship shouldn't be present
> is if it's been filtered out with the ?fields parameter. In this sense,
> relationships are just like attributes.
>
> To your point about the possible overhead of including the relationship
> ids in to-many relationships: this is exactly why "links" can be used as
> a substitute for "data"!