### PR TITLE
Use `ref: true`

### DIFF
--- a/lib/responses/json.js
+++ b/lib/responses/json.js
@@ -69,28 +69,22 @@ module.exports = function json() {
   relationships.forEach(function (relationship) {
     var alias = relationship.alias;
     var collection = relationship.model || relationship.collection;
+
     Model = sails.models[collection];
     // Related model attributes
     opts[alias] = {
       attributes: modelUtils.getOwnAttributes(Model)
     };
     // add models as relationships
-    modelUtils.getRef(Model, function (ref) {
-      opts[alias].ref = ref;
-    });
+    if (modelUtils.isPopulatedRelationship(data, relationship)) {
+      modelUtils.getRef(Model, function (ref) {
+        opts[alias].ref = ref;
+      });
+    } else {
+      opts[alias].ref = true;
+    }
     // Compound Document options
     opts[alias].included = sails.config.jsonapi.compoundDoc;
-  });
-
-  // normalize relationships
-  // jsonapi-serializer expects every relationship to be wrapped in an object
-  relationships.forEach(function (relationship) {
-    var alias = relationship.alias;
-    var value = data[alias];
-    // assume string or number to be id of related ressource
-    if (typeof value === 'string' || typeof value === 'number') {
-      data[alias] = { id: value };
-    }
   });
 
   // Clean up data (removes 'add' and 'remove' functions)

--- a/lib/utils/model-utils.js
+++ b/lib/utils/model-utils.js
@@ -66,3 +66,25 @@ exports.getRelationships = function (req) {
 
   return associations;
 };
+
+// return true if relationship is populated
+exports.isPopulatedRelationship = function (data, relationship) {
+  var _ = require('lodash');
+  // data may be an array of records or a single record
+  var datum = _.isArray(data) ? data[0] : data;
+  var value = datum[relationship.alias];
+  // value may be a single value (to-one) or an array (to-many)
+  var singleValue = _.isArray(value) ? value[0] : value;
+
+  // assume that relationship is not populated if
+  if (
+    // it's a number
+    _.isNumber(singleValue) ||
+    // it's a string
+    _.isString(singleValue)
+  ) {
+    return false;
+  } else {
+    return true;
+  }
+};

--- a/package.json
+++ b/package.json
@@ -29,7 +29,7 @@
     "url": "https://github.com/IanVS/sails-hook-jsonapi"
   },
   "dependencies": {
-    "jsonapi-serializer": "^3.1.0",
+    "jsonapi-serializer": "^3.2.0",
     "lodash": "^4.5.0",
     "pluralize": "^1.1.2",
     "sails-build-dictionary": "^0.10.1"


### PR DESCRIPTION
Will include resource if it's populated otherwise only the id.

`ref: true` was introduced by jsonapi-serializer 3.1.0 and fixed in 3.2.0.